### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-sync.yml
+++ b/.github/workflows/pr-sync.yml
@@ -1,4 +1,7 @@
 name: Open PR from prod to dev
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tawasta/account-analytic/security/code-scanning/2](https://github.com/tawasta/account-analytic/security/code-scanning/2)

To resolve the issue, we need to add an explicit `permissions` block to the workflow. Since the job is opening pull requests, it likely requires `contents: read` and `pull-requests: write`. These permissions limit the GitHub Actions token to the minimum required for branch and PR operations. The `permissions` block should be placed at the workflow root (recommended for consistency, unless per-job scoping is required), i.e., above or below the `name:` and before the `on:` block, but above `jobs:`.

No additional imports or dependencies are necessary; this is a pure YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
