### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,8 @@
 name: CI
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/tawasta/account-analytic/security/code-scanning/1](https://github.com/tawasta/account-analytic/security/code-scanning/1)

To fix this problem, an explicit `permissions` block should be added to the workflow. Since the job uses a reusable workflow (.github/workflows/odoo-pre-commit.yml from tawasta repository), and it is likely that only minimal permissions are required (generally `contents: read`), we should add a top-level `permissions` block specifying minimal required permissions. If the reusable workflow needs additional permissions (like `pull-requests: write`, etc.), those should be added based on requirements—otherwise, specifying only `contents: read` is the recommended base. Add this block at the root level after the workflow `name` and before `on` so all jobs inherit these least privileges by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
